### PR TITLE
Propuesta de cambio para poner sombra y puntas redondeadas a las fotos

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/portafolio.html
+++ b/portafolio.html
@@ -36,6 +36,8 @@
       .imagen {
         width: 48%;
         margin-bottom: 20px;
+        border-radius: 2%;
+        box-shadow: 8px 8px rgb(8, 149, 104);;
       }
 
       .parrafo-p {
@@ -85,6 +87,7 @@
           class="imagen"
         />
       </div>
+      <p>&nbsp;</p>
     </section>
     <footer class="pie">
       Github :


### PR DESCRIPTION
Propuesta de cambio para poner sombra y puntas redondeadas a las fotos del portafolio. Adicionalmente agregué un espacio al final de la página del portafolio para que se ajustara bien la sombra.